### PR TITLE
Add streaming availability for upcoming movies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@
 *   **Detailansicht:** Sehen Sie Poster, Bewertung, Erscheinungsjahr und eine kurze Beschreibung des vorgeschlagenen Titels.
 *   **Trailer-Funktion:** Sehen Sie sich den offiziellen Trailer direkt in der App an (falls auf YouTube verfügbar).
 *   **Watchlist:** Speichern Sie interessante Filme und Serien auf einer persönlichen Watchlist, um sie nicht zu vergessen.
-*   **Demnächst:** Zeigt anstehende Filmveröffentlichungen per Knopfdruck.
+*   **Demnächst:** Zeigt anstehende Filmveröffentlichungen und ihre Streaming-Verfügbarkeit, sofern bekannt.
 *   **Bewertungs-Badge:** Die durchschnittliche Nutzerwertung wird als kleines Badge direkt auf jedem Poster angezeigt.
 *   **TMDb-Link:** In der Detailansicht führt ein Button direkt zur Seite des Films oder der Serie auf TMDb.
 *   **Keine Registrierung:** Alle Daten, inklusive Ihres TMDb API-Schlüssels, werden sicher nur in Ihrem Browser gespeichert.


### PR DESCRIPTION
## Summary
- fetch streaming providers for upcoming movies
- render provider logos or "Kinostart" on upcoming movie cards
- document upcoming streaming availability in the README

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_688865db27388330a623dfaeaea047cd